### PR TITLE
Restore nuklear.h's comments

### DIFF
--- a/deps/nuklearpp/nuklear.h
+++ b/deps/nuklearpp/nuklear.h
@@ -11232,7 +11232,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 /*  stb_truetype.h - v1.24 - public domain */
-/*  authored from 2009-2020 by Sean Barrett / RAD Hoperload Tools */
+/*  authored from 2009-2020 by Sean Barrett / RAD Game Tools */
 /*  */
 /*  ======================================================================= */
 /*  */
@@ -11276,7 +11276,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /*    Bug/warning reports/fixes: */
 /*        "Zer" on mollyrocket       Fabian "ryg" Giesen   github:NiLuJe */
 /*        Cass Everitt               Martins Mozeiko       github:aloucks */
-/*        stoiko (Haemimont Hoperloads)   Cap Petschulat        github:oyvindjam */
+/*        stoiko (Haemimont Games)   Cap Petschulat        github:oyvindjam */
 /*        Brian Hook                 Omar Cornut           github:vassvik */
 /*        Walter van Niftrik         Ryan Griege */
 /*        David Gow                  Peter LaValle */


### PR DESCRIPTION
I guess ce3f713 was a search and replace and `deps` was not excluded from it :trollface:   
I honestly was just going through the commit history for fun when I saw this